### PR TITLE
chore(deregister): tweak order the of deregister process

### DIFF
--- a/client/circuit_breaker.go
+++ b/client/circuit_breaker.go
@@ -49,12 +49,12 @@ func WithCircuitBreaker(dest, src string, nacosClient nacos.Client, opts utils.O
 	return []client.Option{
 		client.WithCircuitBreaker(cbSuite),
 		client.WithCloseCallbacks(func() error {
-			err := cbSuite.Close()
+			err := nacosClient.DeregisterConfig(param, uniqueID)
 			if err != nil {
 				return err
 			}
 			// cancel the configuration listener when client is closed.
-			return nacosClient.DeregisterConfig(param, uniqueID)
+			return cbSuite.Close()
 		}),
 	}
 }

--- a/client/retry.go
+++ b/client/retry.go
@@ -44,10 +44,13 @@ func WithRetryPolicy(dest, src string, nacosClient nacos.Client, opts utils.Opti
 	rc := initRetryContainer(param, dest, nacosClient, uniqueID)
 	return []client.Option{
 		client.WithRetryContainer(rc),
-		client.WithCloseCallbacks(rc.Close),
 		client.WithCloseCallbacks(func() error {
 			// cancel the configuration listener when client is closed.
-			return nacosClient.DeregisterConfig(param, uniqueID)
+			err := nacosClient.DeregisterConfig(param, uniqueID)
+			if err != nil {
+				return err
+			}
+			return rc.Close()
 		}),
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

https://github.com/kitex-contrib/config-nacos/issues/13

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
